### PR TITLE
Add latexrun default directory for auxiliary files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -40,6 +40,10 @@
 *.synctex.gz(busy)
 *.pdfsync
 
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
 ## Auxiliary and intermediate files from other packages:
 # algorithms
 *.alg


### PR DESCRIPTION
**Reasons for making this change:**

Add the default directory where latexrun outputs intermediate files